### PR TITLE
Fix email link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - 🌱 I’m currently working to polish my skills in Python
 - 💬 Ask me about anything
-- 📫 How to reach me [→📧](dhritid1807@gmail.com)
+- 📫 How to reach me [→📧](mailto:dhritid1807@gmail.com)
 - 😄 Pronouns: she/her
 
 <!--


### PR DESCRIPTION
The email in your README was not linked properly. I fixed it by prepending `mailto:` to it. It should now open your email in email clients properly now instead of 404ing.